### PR TITLE
Umlaute in Dateinamen für QT5 repariert (QT4 ungetestet)

### DIFF
--- a/filedownloader.h
+++ b/filedownloader.h
@@ -34,7 +34,7 @@
 
 #include "utils.h"
 #include <sys/types.h>
-#include <sys/utime.h>
+#include <utime.h>
 
 namespace Ui {
     class DateiDownloader;

--- a/parser.cpp
+++ b/parser.cpp
@@ -187,11 +187,11 @@ void Parser::parseFiles(QNetworkReply *reply, QMap<QNetworkReply*, Structureelem
         {
             // URL
             if(currentXmlTag == "href" && url.isEmpty())
-                url.setUrl(QString::fromUtf8(Reader.text().toString().toLatin1()));
+                url.setUrl(QString::fromUtf8(Reader.text().toString().toUtf8()));
 
             // Name
             else if (currentXmlTag == "displayname")
-                name = QString::fromUtf8(Reader.text().toString().toLatin1());
+                name = QString::fromUtf8(Reader.text().toString().toUtf8());
 
             // Größe
             else if (currentXmlTag == "getcontentlength")

--- a/parser.h
+++ b/parser.h
@@ -9,7 +9,6 @@
 #include <QMap>
 #include <QFile>
 #include "mymainwindow.h"
-#include "utils.h"
 
 class Parser : public QObject
 {


### PR DESCRIPTION
Unnötigen include entfernt und einen anderen angepasst.
