### PR TITLE
Fix coding errors under linux.

### DIFF
--- a/browser.cpp
+++ b/browser.cpp
@@ -94,7 +94,7 @@ void Browser::loadSettings()
     ui->maxDateEdit->setDate(settings.value("maxDate", QDate(2042, 1, 1)).toDate());
     settings.endGroup();
 
-    QTextCodec::setCodecForLocale(QTextCodec::codecForName("utf-16"));
+    QTextCodec::setCodecForLocale(QTextCodec::codecForName("utf-8"));
 
     QFile file("data.xml");
     if(!file.open(QIODevice::ReadWrite))

--- a/filedownloader.h
+++ b/filedownloader.h
@@ -32,7 +32,7 @@
 
 #include "utils.h"
 #include <sys/types.h>
-#include <sys/utime.h>
+#include <utime.h>
 
 namespace Ui {
     class DateiDownloader;


### PR DESCRIPTION
Linux does not support utf-16 and so I've changed it to utf-8.
I've also changed "sys/utime.h" to "time.h"