### PR TITLE
Bugfix – StructureDocuments didn't work

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -250,8 +250,8 @@ void Parser::parseFiles(QNetworkReply *reply, QMap<QNetworkReply*, Structureelem
             QLOG_INFO() << file["name"];
         }
 
-        // Wegen der inneren foreach-Schleife in den Kategorien 2,4 und 5 ist diese Übergabe nur noch für die Kategorie 1 und 3
-        if(responseCategory == 1 || responseCategory == 3){
+        // Wegen der inneren foreach-Schleife in den Kategorien 2,4 und 5 ist diese Übergabe nur noch für die Kategorie 0, 1 und 3
+        if(responseCategory == 0 ||responseCategory == 1 || responseCategory == 3){
 
             Structureelement *dir = Utils::getDirectoryItem(currentCourse, urlParts);
 


### PR DESCRIPTION
This PR fixes a selfmade bug of my last PR. Sorry!

I've forgotten to include "responseCategory == 0" into the if statement…