### PR TITLE
Fix synchronisedRole for SharedDocuments and AssignmentsDocuments 

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -164,7 +164,7 @@ void Parser::parseFiles(QNetworkReply *reply, QMap<QNetworkReply*, Structureelem
                 QJsonObject assignmentDoc = assignmentElement.toObject();
 
                 filename = assignmentDoc["fileName"].toString();
-                filesize = assignmentDoc["fileSize"].toInt();
+                filesize = assignmentDoc["fileSize"].toString().toInt();
                 timestamp = assignmentDoc["modifiedTimestamp"].toInt();
                 url = assignmentDoc["downloadUrl"].toString();
                 urlParts = url.split('/');

--- a/parser.cpp
+++ b/parser.cpp
@@ -250,8 +250,8 @@ void Parser::parseFiles(QNetworkReply *reply, QMap<QNetworkReply*, Structureelem
             QLOG_INFO() << file["name"];
         }
 
-        // Wegen der inneren foreach-Schleife in den Kategorien 2,4 und 5 ist diese Übergabe nur noch für die Kategorie 1 und 3
-        if(responseCategory == 1 || responseCategory == 3){
+        // Wegen der inneren foreach-Schleife in den Kategorien 2,4 und 5 ist diese Übergabe nur noch für die Kategorie 0, 1 und 3
+        if(responseCategory == 0 ||responseCategory == 1 || responseCategory == 3){
 
             Structureelement *dir = Utils::getDirectoryItem(currentCourse, urlParts);
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -177,10 +177,12 @@ void Utils::checkAllFilesIfSynchronised(QLinkedList<Structureelement*> items, QS
 
         QString filePath = getElementLocalPath(item, downloadDirectory, true, false);
         QFileInfo fileInfo(filePath);
+        QString url = item->data(urlRole).toUrl().toString();
 
-        // Vergleich der Dateigröße sowie des Änderungsdatums
-        if(fileInfo.exists() && fileInfo.isFile() &&
-           fileInfo.size() == item->data(sizeRole).toInt()/* &&
+        // Für Gemeinsame Dokumente gibt es keine Information über die Dateigröße
+        if(url.contains("collaboration")) {
+        if(fileInfo.exists() && fileInfo.isFile()/* &&
+           fileInfo.size() == item->data(sizeRole).toInt() &&
            fileInfo.lastModified() == item->data(dateRole).toDateTime()*/)
         {
             item->setData(SYNCHRONISED, synchronisedRole);
@@ -188,6 +190,21 @@ void Utils::checkAllFilesIfSynchronised(QLinkedList<Structureelement*> items, QS
         else
         {
             item->setData(NOT_SYNCHRONISED, synchronisedRole);
+        }
+        }
+        // bei allen anderen Dateien hingegen schon
+        else
+        {
+            if(fileInfo.exists() && fileInfo.isFile() &&
+                fileInfo.size() == item->data(sizeRole).toInt()/* &&
+                fileInfo.lastModified() == item->data(dateRole).toDateTime()*/)
+            {
+                item->setData(SYNCHRONISED, synchronisedRole);
+            }
+            else
+            {
+                item->setData(NOT_SYNCHRONISED, synchronisedRole);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fix the synchronisedRole for SharedDocuments and AssignmentsDocuments.

For AssignmentsDocuments the file size generation was incorrect.
SharedDocuments does not offer a file size and so the "checkAllFilesIfSynchronised" method has to check the type of the request.