### PR TITLE
Fix override bug.

### DIFF
--- a/browser.cpp
+++ b/browser.cpp
@@ -517,7 +517,7 @@ void Browser::on_syncPushButton_clicked()
         QString filename = currentElement->text();
 
         bool downloadFile = options->isOverrideFilesCheckBoxChecked() &&
-                QFileInfo(directory, filename).lastModified().toMSecsSinceEpoch()/1000 < currentElement->data(dateRole).toInt();
+                currentElement->data(synchronisedRole) == NOT_SYNCHRONISED;
         downloadFile = downloadFile || !directory.exists(filename);
 
         // Datei existiert noch nicht


### PR DESCRIPTION
For me, the override file option does not work. The files are marked as
"NOT_SYNCHRONISED" but they will not downloaded. I figured out that the
line:
`QFileInfo(directory, filename).lastModified().toMSecsSinceEpoch()/1000 <  currentElement->data(dateRole).toInt();`
does not return true.

And so, I've replaced this line with the synchronisedRole check.
Now it works. Tested on linux.