### PR TITLE
Suggestion: Adjust options.ui.

### DIFF
--- a/options.ui
+++ b/options.ui
@@ -71,7 +71,7 @@
            <string>Einloggen</string>
           </property>
           <property name="icon">
-           <iconset resource="icons/icons.qrc">
+           <iconset>
             <normaloff>:/icons/login.png</normaloff>:/icons/login.png</iconset>
           </property>
           <property name="default">
@@ -83,6 +83,19 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QGroupBox" name="downloadFolderBox">
@@ -106,13 +119,26 @@
          <string>Durchsuchen</string>
         </property>
         <property name="icon">
-         <iconset resource="icons/icons.qrc">
+         <iconset>
           <normaloff>:/icons/downloadDirectory.png</normaloff>:/icons/downloadDirectory.png</iconset>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QGroupBox" name="filterOptionsBox">
@@ -178,6 +204,19 @@
     </widget>
    </item>
    <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <widget class="QGroupBox" name="automatisationBox">
      <property name="title">
       <string>Automatisation</string>
@@ -215,6 +254,19 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QGroupBox" name="misc">
@@ -279,13 +331,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="aboutButton">
-     <property name="text">
-      <string>Über Sync-my-L2P</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -298,10 +343,15 @@
      </property>
     </spacer>
    </item>
+   <item>
+    <widget class="QPushButton" name="aboutButton">
+     <property name="text">
+      <string>Über Sync-my-L2P</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
- <resources>
-  <include location="icons/icons.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
This PR is only a suggestion to improve the gui of the options.

For me, I dislike the gap at the end of the options tap. And so my simple idea is to add a few Vertical Spacer to rearrange the exists widgets elements.

It is not perfect but better than such a big gap. 
