### PR TITLE
Fix #81 - date filter fix

### DIFF
--- a/browser.cpp
+++ b/browser.cpp
@@ -154,7 +154,7 @@ void Browser::saveSettings()
 
     settings.beginGroup("dateFilter");
     settings.setValue("dateFilter",     ui->dateFilterCheckBox->isChecked());
-    settings.setValue("mindate",        ui->minDateEdit->date());
+    settings.setValue("minDate",        ui->minDateEdit->date());
     settings.setValue("maxDate",        ui->maxDateEdit->date());
     settings.endGroup();
 


### PR DESCRIPTION
This PR fixes #81– the date filter. 
The bug was caused on a spelling mistake.